### PR TITLE
feat(csi): add code to discover the target

### DIFF
--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -46,8 +46,8 @@ type Connector struct {
 	Multipath        bool     `json:"multipath"`
 	RetryCount       int32    `json:"retry_count"`
 	CheckInterval    int32    `json:"check_interval"`
-	Discovery        bool     `json:"discovery"`
-	CHAPDiscovery    bool     `json:"chap_discovery"`
+	DoDiscovery      bool     `json:"do_discovery"`
+	DoCHAPDiscovery  bool     `json:"do_chap_discovery"`
 }
 
 func init() {
@@ -277,9 +277,9 @@ func Connect(c Connector) (string, error) {
 			}
 		}
 
-		if c.Discovery {
+		if c.DoDiscovery {
 			// build discoverydb and discover iscsi target
-			if err := Discovery(p, iFace, c.DiscoverySecrets, c.CHAPDiscovery); err != nil {
+			if err := Discovery(p, iFace, c.DiscoverySecrets, c.DoCHAPDiscovery); err != nil {
 				debug.Printf("Error in discovery of the target: %s\n", err.Error())
 				lastErr = err
 				continue
@@ -287,7 +287,7 @@ func Connect(c Connector) (string, error) {
 		}
 
 		// Make sure we don't log the secrets
-		err := CreateDBEntry(c.TargetIqn, p, iFace, c.DiscoverySecrets, c.SessionSecrets, c.CHAPDiscovery)
+		err := CreateDBEntry(c.TargetIqn, p, iFace, c.DiscoverySecrets, c.SessionSecrets, c.DoCHAPDiscovery)
 		if err != nil {
 			debug.Printf("Error creating db entry: %s\n", err.Error())
 			continue

--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -88,13 +88,17 @@ func ShowInterface(iface string) (string, error) {
 }
 
 // CreateDBEntry sets up a node entry for the specified tgt in the nodes iscsi nodes db
-func CreateDBEntry(tgtIQN, portal, iFace string, discoverySecrets, sessionSecrets Secrets) error {
+func CreateDBEntry(tgtIQN, portal, iFace string, discoverySecrets, sessionSecrets Secrets, chapDiscovery bool) error {
 	debug.Println("Begin CreateDBEntry...")
+	if !chapDiscovery {
+		return nil
+	}
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
 	_, err := iscsiCmd(append(baseArgs, []string{"-I", iFace, "-o", "new"}...)...)
 	if err != nil {
 		return err
 	}
+
 	if discoverySecrets.SecretsType == "chap" {
 		debug.Printf("Setting CHAP Discovery...")
 		createCHAPEntries(baseArgs, discoverySecrets, true)
@@ -103,10 +107,44 @@ func CreateDBEntry(tgtIQN, portal, iFace string, discoverySecrets, sessionSecret
 	if sessionSecrets.SecretsType == "chap" {
 		debug.Printf("Setting CHAP Session...")
 		createCHAPEntries(baseArgs, sessionSecrets, false)
-
 	}
+
 	return err
 
+}
+
+func updateISCSIDiscoverydb(tp, iface string, discoverySecrets Secrets) error {
+	baseArgs := []string{"-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", iface}
+	_, err := iscsiCmd(append(baseArgs, []string{"-o", "update", "-n", "discovery.sendtargets.auth.authmethod", "-v", "CHAP"}...)...)
+	if err != nil {
+		return fmt.Errorf("failed to update discoverydb with CHAP, err: %v", err)
+	}
+
+	return createCHAPEntries(baseArgs, discoverySecrets, true)
+}
+
+// Discovery discover the iscsi target
+func Discovery(tp, iface string, discoverySecrets Secrets, chapDiscovery bool) error {
+	debug.Println("Begin Discovery...")
+	baseArgs := []string{"-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", iface}
+	out, err := iscsiCmd(append(baseArgs, []string{"-o", "new"}...)...)
+	if err != nil {
+		return fmt.Errorf("failed to create new entry of target in discoverydb, output: %v, err: %v", string(out), err)
+	}
+
+	if chapDiscovery {
+		if err := updateISCSIDiscoverydb(tp, iface, discoverySecrets); err != nil {
+			return err
+		}
+	}
+
+	_, err = iscsiCmd(append(baseArgs, []string{"--discover"}...)...)
+	if err != nil {
+		//delete the discoverydb record
+		iscsiCmd(append(baseArgs, []string{"-o", "delete"}...)...)
+		return fmt.Errorf("failed to sendtargets to portal %s, err: %v", tp, err)
+	}
+	return nil
 }
 
 func createCHAPEntries(baseArgs []string, secrets Secrets, discovery bool) error {
@@ -114,14 +152,14 @@ func createCHAPEntries(baseArgs []string, secrets Secrets, discovery bool) error
 	debug.Printf("Begin createCHAPEntries (discovery=%t)...", discovery)
 	if discovery {
 		args = append(baseArgs, []string{"-o", "update",
-			"-n", "node.discovery.auth.authmethod", "-v", "CHAP",
-			"-n", "node.discovery.auth.username", "-v", secrets.UserName,
-			"-n", "node.discovery.auth.password", "-v", secrets.Password}...)
+			"-n", "discovery.sendtargets.auth.authmethod", "-v", "CHAP",
+			"-n", "discovery.sendtargets.auth.username", "-v", secrets.UserName,
+			"-n", "discovery.sendtargets.auth.password", "-v", secrets.Password}...)
 		if secrets.UserNameIn != "" {
-			args = append(args, []string{"-n", "node.discovery.auth.username_in", "-v", secrets.UserNameIn}...)
+			args = append(args, []string{"-n", "discovery.sendtargets.auth.username_in", "-v", secrets.UserNameIn}...)
 		}
-		if secrets.UserNameIn != "" {
-			args = append(args, []string{"-n", "node.discovery.auth.password_in", "-v", secrets.PasswordIn}...)
+		if secrets.PasswordIn != "" {
+			args = append(args, []string{"-n", "discovery.sendtargets.auth.password_in", "-v", secrets.PasswordIn}...)
 		}
 
 	} else {
@@ -133,13 +171,17 @@ func createCHAPEntries(baseArgs []string, secrets Secrets, discovery bool) error
 		if secrets.UserNameIn != "" {
 			args = append(args, []string{"-n", "node.session.auth.username_in", "-v", secrets.UserNameIn}...)
 		}
-		if secrets.UserNameIn != "" {
+		if secrets.PasswordIn != "" {
 			args = append(args, []string{"-n", "node.session.auth.password_in", "-v", secrets.PasswordIn}...)
 		}
 	}
-	_, err := iscsiCmd(args...)
-	return err
 
+	_, err := iscsiCmd(args...)
+	if err != nil {
+		return fmt.Errorf("failed to update discoverydb with CHAP, err: %v", err)
+	}
+
+	return nil
 }
 
 // GetSessions retrieves a list of current iscsi sessions on the node
@@ -151,7 +193,13 @@ func GetSessions() (string, error) {
 
 // Login performs an iscsi login for the specified target
 func Login(tgtIQN, portal string) error {
-	_, err := iscsiCmd([]string{"-m", "node", "-T", tgtIQN, "-p", portal, "-l"}...)
+	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
+	_, err := iscsiCmd(append(baseArgs, []string{"-l"}...)...)
+	if err != nil {
+		//delete the node record from database
+		iscsiCmd(append(baseArgs, []string{"-o", "delete"}...)...)
+		return fmt.Errorf("failed to sendtargets to portal %s, err: %v", portal, err)
+	}
 	return err
 }
 
@@ -173,5 +221,11 @@ func DeleteDBEntry(tgtIQN string) error {
 	args := []string{"-m", "node", "-T", tgtIQN, "-o", "delete"}
 	iscsiCmd(args...)
 	return nil
+}
 
+// DeleteIFace delete the iface
+func DeleteIFace(iface string) error {
+	debug.Println("Begin DeleteIFace...")
+	iscsiCmd([]string{"-m", "iface", "-I", iface, "-o", "delete"}...)
+	return nil
 }

--- a/iscsi/iscsiadm_test.go
+++ b/iscsi/iscsiadm_test.go
@@ -1,0 +1,139 @@
+package iscsi
+
+import "testing"
+
+func TestDiscovery(t *testing.T) {
+	execCommand = fakeExecCommand
+	tests := map[string]struct {
+		tgtPortal        string
+		iface            string
+		discoverySecret  Secrets
+		chapDiscovery    bool
+		wantErr          bool
+		mockedStdout     string
+		mockedExitStatus int
+	}{
+		"DiscoverySuccess": {
+			tgtPortal:        "172.18.0.2:3260",
+			iface:            "default",
+			chapDiscovery:    false,
+			mockedStdout:     "172.18.0.2:3260,1 iqn.2016-09.com.openebs.jiva:store1\n",
+			mockedExitStatus: 0,
+		},
+
+		"ConnectionFailure": {
+			tgtPortal:     "172.18.0.2:3262",
+			iface:         "default",
+			chapDiscovery: false,
+			mockedStdout: `iscsiadm: cannot make connection to 172.18.0.2: Connection refused
+iscsiadm: cannot make connection to 172.18.0.2: Connection refused
+iscsiadm: connection login retries (reopen_max) 5 exceeded
+iscsiadm: Could not perform SendTargets discovery: encountered connection failure\n`,
+			mockedExitStatus: 4,
+			wantErr:          true,
+		},
+
+		"ChapEntrySuccess": {
+			tgtPortal:     "172.18.0.2:3260",
+			iface:         "default",
+			chapDiscovery: true,
+			discoverySecret: Secrets{
+				UserNameIn: "dummyuser",
+				PasswordIn: "dummypass",
+			},
+			mockedStdout:     "172.18.0.2:3260,1 iqn.2016-09.com.openebs.jiva:store1\n",
+			mockedExitStatus: 0,
+		},
+
+		"ChapEntryFailure": {
+			tgtPortal: "172.18.0.2:3260",
+			iface:     "default",
+			discoverySecret: Secrets{
+				UserNameIn: "dummyuser",
+				PasswordIn: "dummypass",
+			},
+			chapDiscovery: true,
+			mockedStdout: `iscsiadm: Login failed to authenticate with target
+iscsiadm: discovery login to 172.18.0.2 rejected: initiator error (02/01), non-retryable, giving up
+iscsiadm: Could not perform SendTargets discovery.\n`,
+			mockedExitStatus: 4,
+			wantErr:          true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockedExitStatus = tt.mockedExitStatus
+			mockedStdout = tt.mockedStdout
+			err := Discovery(tt.tgtPortal, tt.iface, tt.discoverySecret, tt.chapDiscovery)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Discovery() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestCreateDBEntry(t *testing.T) {
+	execCommand = fakeExecCommand
+	tests := map[string]struct {
+		tgtPortal        string
+		tgtIQN           string
+		iface            string
+		discoverySecret  Secrets
+		sessionSecret    Secrets
+		chapDiscovery    bool
+		wantErr          bool
+		mockedStdout     string
+		mockedExitStatus int
+	}{
+		"CreateDBEntrySuccess": {
+			tgtPortal:        "192.168.1.107:3260",
+			tgtIQN:           "iqn.2010-10.org.openstack:volume-eb393993-73d0-4e39-9ef4-b5841e244ced",
+			iface:            "default",
+			chapDiscovery:    false,
+			mockedStdout:     nodeDB,
+			mockedExitStatus: 0,
+		},
+		"CreateDBEntryWithChapDiscoverySuccess": {
+			tgtPortal: "192.168.1.107:3260",
+			tgtIQN:    "iqn.2010-10.org.openstack:volume-eb393993-73d0-4e39-9ef4-b5841e244ced",
+			iface:     "default",
+			discoverySecret: Secrets{
+				UserNameIn:  "dummyuser",
+				PasswordIn:  "dummypass",
+				SecretsType: "chap",
+			},
+			sessionSecret: Secrets{
+				UserNameIn:  "dummyuser",
+				PasswordIn:  "dummypass",
+				SecretsType: "chap",
+			},
+			chapDiscovery:    true,
+			mockedStdout:     nodeDB,
+			mockedExitStatus: 0,
+		},
+		"CreateDBEntryWithChapDiscoveryFailure": {
+			tgtPortal:        "172.18.0.2:3260",
+			tgtIQN:           "iqn.2016-09.com.openebs.jiva:store1",
+			iface:            "default",
+			chapDiscovery:    true,
+			mockedStdout:     "iscsiadm: No records found\n",
+			mockedExitStatus: 21,
+			wantErr:          true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockedExitStatus = tt.mockedExitStatus
+			mockedStdout = tt.mockedStdout
+			err := CreateDBEntry(tt.tgtIQN, tt.tgtPortal, tt.iface, tt.discoverySecret, tt.sessionSecret, tt.chapDiscovery)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateDBEntry() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This commit add the feature to discover the target based on the flag Discovery,
which can be set while initializing iscsi.Connector structure. It also adds
another flag CHAPDiscovery to proceed to discover the target without secrets.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
- Introducing two flags Discovery, CHAPDiscovery for discovery and authentication purpose.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
